### PR TITLE
feat: SEO meta tags, tag pages, and incremental generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data/.sitegen-cache.json
+site/

--- a/bin/sitegen.pl
+++ b/bin/sitegen.pl
@@ -1,270 +1,214 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
+use Getopt::Long;
 use Template;
-use Data::Dumper;
-use Text::Markdown::Discount qw(markdown);
-#use Text::MultiMarkdown 'markdown';
+use YAML::Tiny;
 
 use FindBin qw($Bin);
 use lib "$Bin/../lib";
 
-our $data_dir = "$Bin/../data";
-our $top_dir = "$data_dir/top";
-our $news_dir = "$data_dir/news";
-our $site_name = 'Hong Kong Linux User Group - 香港Linux用家協會(HKLUG)';
-our $site_folder = "$Bin/../site";
-our $archive_folder = "$site_folder/archive";
+use Sitegen::DataLoader qw(load_data load_announce);
+use Sitegen::Cache      qw(load_cache save_cache is_fresh update_cache);
+use Sitegen::SEO        qw(seo_meta);
+use Sitegen::Tags       qw(collect_tags tag_slug gen_tag_pages);
 
-sub main {
-    my $tt = Template->new({
-        INCLUDE_PATH => "$Bin/../template",
-        INTERPOLATE  => 0,
-    }) || die "$Template::ERROR\n";
-    
-    gen_home($tt);
-    gen_pages($tt);
-    gen_archive($tt);
+my $force = 0;
+GetOptions('force' => \$force);
+
+our $base_dir       = "$Bin/..";
+our $data_dir       = "$base_dir/data";
+our $top_dir        = "$data_dir/top";
+our $news_dir       = "$data_dir/news";
+our $site_folder    = "$base_dir/site";
+our $archive_folder = "$site_folder/archive";
+our $cache_file     = "$data_dir/.sitegen-cache.json";
+our $config_file    = "$data_dir/sitegen.yaml";
+
+=head1 NAME
+
+sitegen.pl - Static site generator for HKLUG
+
+=head1 SYNOPSIS
+
+  perl bin/sitegen.pl [--force]
+
+=head1 DESCRIPTION
+
+Generates the HKLUG static site from .txt source files.  With C<--force> all
+pages are rebuilt regardless of cache; without it, archive posts whose source
+file has not changed are skipped.
+
+=cut
+
+sub load_config {
+    die "Missing config file: $config_file\n" unless -f $config_file;
+    my $yaml = YAML::Tiny->read($config_file)
+        or die "Cannot parse $config_file: " . YAML::Tiny->errstr . "\n";
+    return $yaml->[0];
 }
 
+sub main {
+    my $config = load_config();
+    my $cache  = $force ? {} : load_cache($cache_file);
+
+    my $tt = Template->new({
+        INCLUDE_PATH => "$base_dir/template",
+        INTERPOLATE  => 0,
+    }) || die "$Template::ERROR\n";
+
+    gen_home($tt, $config);
+    gen_pages($tt, $config);
+    my $all_posts = gen_archive($tt, $config, $cache);
+    gen_tags($tt, $config, $all_posts);
+
+    save_cache($cache_file, $cache);
+}
+
+=head2 gen_home($tt, $config)
+
+Renders the site homepage (C<index.html>) from the five most recent news posts.
+
+=cut
+
 sub gen_home {
-    my ($tt) = @_;
+    my ($tt, $config) = @_;
     my @filelist;
-    opendir(DIRIN, $news_dir) or die $!;
-    while (my $file = readdir(DIRIN)) {
-        if ($file =~ m/\.txt$/) {
-            push @filelist, $file;
-        }
-    }
-    closedir(DIRIN);
+    opendir(my $dh, $news_dir) or die $!;
+    while (my $file = readdir($dh)) { push @filelist, $file if $file =~ m/\.txt$/ }
+    closedir($dh);
     my @sortlist = sort @filelist;
-    
-    my $total = @sortlist;
+    my $total    = scalar @sortlist;
 
     my @news_posts;
     for my $i (1..5) {
         last if ($total - $i < 0);
-        my $post = load_data("$news_dir/$sortlist[$total - $i]");
-        print Dumper($post);
-        push @news_posts, $post; 
-    } 
+        push @news_posts, load_data("$news_dir/$sortlist[$total - $i]");
+    }
 
-    my $announce = load_announce();
-
-    my $vars = {
-        title => "$site_name \&gt News",
-        news => \@news_posts,
+    my $announce = load_announce($top_dir);
+    my $seo_post = { title => $config->{site_name} . ' > News', content => '' };
+    $tt->process('news.html', {
+        title    => $config->{site_name} . ' > News',
+        news     => \@news_posts,
         announce => $announce,
-    };
-
-    print Dumper($vars);
-
-    $tt->process('news.html', $vars, "$site_folder/index.html")
-        || die $tt->error(), "\n";
+        seo      => seo_meta($seo_post, $config, '/'),
+    }, "$site_folder/index.html") || die $tt->error();
 }
+
+=head2 gen_pages($tt, $config)
+
+Renders static .txt pages in the data root directory into C<site/>.
+
+=cut
 
 sub gen_pages {
-    my ($tt) = @_;
+    my ($tt, $config) = @_;
     my @filelist;
-    opendir(DIRIN, $data_dir) or die $!;
-    while (my $file = readdir(DIRIN)) {
-        if ($file =~ m/\.txt$/) {
-            push @filelist, $file;
-        }
-    }
-    closedir(DIRIN);
+    opendir(my $dh, $data_dir) or die $!;
+    while (my $file = readdir($dh)) { push @filelist, $file if $file =~ m/\.txt$/ }
+    closedir($dh);
 
     for my $file (@filelist) {
-        my $post = load_data("$data_dir/$file");
-        print Dumper($post);
-
-        my $announce = load_announce();
-        my $vars = {
-            title => "$site_name \&gt ".$post->{title},
-            post => $post,
+        my $post     = load_data("$data_dir/$file");
+        my $announce = load_announce($top_dir);
+        (my $newfile = $file) =~ s/\.txt$/.html/;
+        $tt->process('page.html', {
+            title    => $config->{site_name} . ' > ' . $post->{title},
+            post     => $post,
             announce => $announce,
-        };
-
-        print Dumper($vars);
-
-        my $newfile = $file;
-        $newfile =~ s/\.txt/\.html/g;
-        print "$newfile \n";
-        $tt->process('page.html', $vars, "$site_folder/$newfile")
-            || die $tt->error(), "\n";
+            seo      => seo_meta($post, $config, "/$newfile"),
+        }, "$site_folder/$newfile") || die $tt->error();
     }
 }
 
+=head2 gen_archive($tt, $config, $cache)
+
+Renders individual archive post pages (with incremental cache) and the archive
+list page.  Returns an arrayref of all posts, newest-first, for use by
+C<gen_tags>.
+
+=cut
+
 sub gen_archive {
-    my ($tt) = @_;
+    my ($tt, $config, $cache) = @_;
     my @filelist;
-    opendir(DIRIN, $news_dir) or die $!;
-    while (my $file = readdir(DIRIN)) {
-        if ($file =~ m/\.txt$/) {
-            push @filelist, $file;
-        }
-    }
-    closedir(DIRIN);
+    opendir(my $dh, $news_dir) or die $!;
+    while (my $file = readdir($dh)) { push @filelist, $file if $file =~ m/\.txt$/ }
+    closedir($dh);
 
     my @sortlist = sort @filelist;
-    my $total = @sortlist;
-
-    my $count = 0;
-
-    my @allnews;
+    my $total    = scalar @sortlist;
+    my (@allnews, $count);
+    $count = 0;
 
     for my $file (@sortlist) {
-        my $post = load_data("$news_dir/$file");
-        print Dumper($post);
+        (my $newfile = $file) =~ s/\.txt$/.html/;
+        my $srcfile = "$news_dir/$file";
+        my $outfile = "$archive_folder/$newfile";
 
-        my $newfile = $file;
-        $newfile =~ s/\.txt/\.html/g;
-
-        my $startfile = $sortlist[$total-1];
-        my $endfile = $sortlist[0];
-
-        my $preindex = $count+1;
-        if ($count+1 >= $total) {
-            $preindex = $count;
-        } 
-
-        my $nextindex = $count-1;
-        if ($count-1 < 0) {
-            $nextindex = 0;
-        }
-
-        my $prevfile = $sortlist[$preindex];
-        my $nextfile = $sortlist[$nextindex];
-
-        $startfile =~ s/\.txt/\.html/g;
-        $endfile =~ s/\.txt/\.html/g;
-        $prevfile =~ s/\.txt/\.html/g;
-        $nextfile =~ s/\.txt/\.html/g;
-
-        my $vars = {
-            title => "$site_name \&gt Archive \&gt ".$post->{title},
-            post => $post,
-            url => { 
-                front => "/archive/$startfile",
-                end => "/archive/$endfile",
-                prev => "/archive/$prevfile",
-                next => "/archive/$nextfile",
-                home => "/archive/",
-                hometitle => "Archive",
-            },
-        };
-
+        my $post = load_data($srcfile);
         $post->{url} = "/archive/$newfile";
         push @allnews, $post;
 
-        print Dumper($vars);
-
-        print "$newfile \n";
-        $tt->process('archive.html', $vars, "$archive_folder/$newfile")
-            || die $tt->error(), "\n";
-
-        $count ++;
-    }
-
-    my @revesenews;
-    while (my $post = pop(@allnews) ) {
-        push @revesenews, $post;
-    }
-    print Dumper(\@revesenews);
-    my $announce = load_announce();
-    my $vars = {
-            title => "$site_name \&gt Archive",
-            pagetitle => "Archives",
-            news => \@revesenews,
-            announce => $announce,
-        };
-    print Dumper($vars);
-    $tt->process('archive_list.html', $vars, "$archive_folder/index.html")
-            || die $tt->error(), "\n";
-}
-
-sub load_data {
-    my ($filename) = @_;
-    print "$filename\n";
-    my %post;
-
-    my $iscontent = 0;
-
-    open (FILEIN, "<$filename");
-    while (<FILEIN>) {
-        my $line = $_;
-        if ($line =~m/^\/\//) {
+        if (!$force && is_fresh($cache, $srcfile, $outfile)) {
+            print "SKIP $file\n";
+            $count++;
             next;
         }
-        if ($iscontent == 0) {
-            chomp $line;
-            if ($line =~m/^Date:.*/) {
-                my ($key, $value) = split /:/, $line, 2;
-                $post{date} = trim($value); 
-            } 
-            if ($line =~m/^Author:.*/) {
-                my ($key, $value) = split /:/, $line, 2;
-                $post{author} = trim($value);
-            } 
-            if ($line =~m/^Title:.*/) {
-                my ($key, $value) = split /:/, $line, 2;
-                $post{title} = trim($value);
-            }
-            if ($line =~m/^Content:.*/) {
-                my ($key, $value) = split /:/, $line, 2;
-                $post{content} = $value;
-                $iscontent = 1;
-            }
-        } else {
-           $post{content} .= $line; 
-        }
-    };
-    close FILEIN;
-    my $org = $post{content};
-    $post{content} = markdown($org);
-    return \%post;
-}
 
-sub load_announce {
-    my @filelist;
-    opendir(DIRIN, $top_dir) or die $!;
-    while (my $file = readdir(DIRIN)) {
-        if ($file =~ m/\.txt$/) {
-            push @filelist, $file;
-        }
+        my $preindex  = ($count + 1 >= $total) ? $count     : $count + 1;
+        my $nextindex = ($count - 1 < 0)       ? 0          : $count - 1;
+
+        (my $prevfile  = $sortlist[$preindex])  =~ s/\.txt$/.html/;
+        (my $nextfile2 = $sortlist[$nextindex]) =~ s/\.txt$/.html/;
+        (my $startfile = $sortlist[$total - 1]) =~ s/\.txt$/.html/;
+        (my $endfile   = $sortlist[0])          =~ s/\.txt$/.html/;
+
+        $tt->process('archive.html', {
+            title => $config->{site_name} . ' > Archive > ' . $post->{title},
+            post  => $post,
+            url   => {
+                front     => "/archive/$startfile",
+                end       => "/archive/$endfile",
+                prev      => "/archive/$prevfile",
+                next      => "/archive/$nextfile2",
+                home      => "/archive/",
+                hometitle => "Archive",
+            },
+            seo => seo_meta($post, $config, "/archive/$newfile"),
+        }, $outfile) || die $tt->error();
+
+        update_cache($cache, $srcfile);
+        $count++;
     }
-    closedir(DIRIN);
-    my @sortlist = sort @filelist;
-    my $filename = pop @sortlist;
 
-    return load_data("$top_dir/$filename");
+    # Archive list — always regenerate
+    my @reversed  = reverse @allnews;
+    my $announce  = load_announce($top_dir);
+    my $seo_post  = { title => $config->{site_name} . ' > Archive', content => '' };
+    $tt->process('archive_list.html', {
+        title     => $config->{site_name} . ' > Archive',
+        pagetitle => 'Archives',
+        news      => \@reversed,
+        announce  => $announce,
+        seo       => seo_meta($seo_post, $config, '/archive/'),
+    }, "$archive_folder/index.html") || die $tt->error();
+
+    return [reverse @allnews];  # newest-first for tags
 }
 
-sub trim {
-    my $string = shift;
-    $string =~ s/^\s+//;
-    $string =~ s/\s+$//;
-    return $string;
+=head2 gen_tags($tt, $config, $all_posts)
+
+Collects tags from all posts and renders C<site/tags/index.html> and
+C<site/tags/E<lt>slugE<gt>/index.html> for each tag.
+
+=cut
+
+sub gen_tags {
+    my ($tt, $config, $all_posts) = @_;
+    my $tags = collect_tags(@$all_posts);
+    gen_tag_pages($tt, $tags, $site_folder, $config);
 }
 
 main();
-
-__END__
-my $tt = Template->new({
-    INCLUDE_PATH => '../template',
-    INTERPOLATE  => 1,
-}) || die "$Template::ERROR\n";
-
-my $vars = {
-    title     => 'Count Edward van Halen',
-    debt     => '3 riffs and a solo',
-    deadline => 'the next chorus',
-    news => [{"title" => "aaa", content=>"ldsuifsd", "author" =>"bbb"} , {"title" =>"1111", content=>"87sdfsdfs", "author" =>"222"} ,
-
-    ],
-    post => {title=>'aaa', author=>'bbb'
-    },
-};
-
-$tt->process('news_section.html', $vars)
-    || die $tt->error(), "\n";

--- a/bin/sitegen.pl
+++ b/bin/sitegen.pl
@@ -4,6 +4,7 @@ use warnings;
 use Getopt::Long;
 use Template;
 use YAML::Tiny;
+use File::Path qw(make_path);
 
 use FindBin qw($Bin);
 use lib "$Bin/../lib";
@@ -11,7 +12,7 @@ use lib "$Bin/../lib";
 use Sitegen::DataLoader qw(load_data load_announce);
 use Sitegen::Cache      qw(load_cache save_cache is_fresh update_cache);
 use Sitegen::SEO        qw(seo_meta);
-use Sitegen::Tags       qw(collect_tags tag_slug gen_tag_pages);
+use Sitegen::Tags       qw(collect_tags gen_tag_pages);
 
 my $force = 0;
 GetOptions('force' => \$force);
@@ -56,6 +57,8 @@ sub main {
         INCLUDE_PATH => "$base_dir/template",
         INTERPOLATE  => 0,
     }) || die "$Template::ERROR\n";
+
+    make_path($site_folder, $archive_folder);
 
     gen_home($tt, $config);
     gen_pages($tt, $config);
@@ -157,11 +160,11 @@ sub gen_archive {
             next;
         }
 
-        my $preindex  = ($count + 1 >= $total) ? $count     : $count + 1;
-        my $nextindex = ($count - 1 < 0)       ? 0          : $count - 1;
+        my $previndex = ($count - 1 < 0)        ? 0           : $count - 1;   # older post
+        my $nextindex = ($count + 1 >= $total)  ? $total - 1  : $count + 1;   # newer post
 
-        (my $prevfile  = $sortlist[$preindex])  =~ s/\.txt$/.html/;
-        (my $nextfile2 = $sortlist[$nextindex]) =~ s/\.txt$/.html/;
+        (my $prevfile = $sortlist[$previndex]) =~ s/\.txt$/.html/;
+        (my $nextfile = $sortlist[$nextindex]) =~ s/\.txt$/.html/;
         (my $startfile = $sortlist[$total - 1]) =~ s/\.txt$/.html/;
         (my $endfile   = $sortlist[0])          =~ s/\.txt$/.html/;
 
@@ -172,7 +175,7 @@ sub gen_archive {
                 front     => "/archive/$startfile",
                 end       => "/archive/$endfile",
                 prev      => "/archive/$prevfile",
-                next      => "/archive/$nextfile2",
+                next      => "/archive/$nextfile",
                 home      => "/archive/",
                 hometitle => "Archive",
             },
@@ -184,18 +187,18 @@ sub gen_archive {
     }
 
     # Archive list — always regenerate
-    my @reversed  = reverse @allnews;
+    my @newest_first = reverse @allnews;
     my $announce  = load_announce($top_dir);
     my $seo_post  = { title => $config->{site_name} . ' > Archive', content => '' };
     $tt->process('archive_list.html', {
         title     => $config->{site_name} . ' > Archive',
         pagetitle => 'Archives',
-        news      => \@reversed,
+        news      => \@newest_first,
         announce  => $announce,
         seo       => seo_meta($seo_post, $config, '/archive/'),
     }, "$archive_folder/index.html") || die $tt->error();
 
-    return [reverse @allnews];  # newest-first for tags
+    return \@newest_first;  # newest-first for tags
 }
 
 =head2 gen_tags($tt, $config, $all_posts)

--- a/bin/sitegen.pl
+++ b/bin/sitegen.pl
@@ -210,8 +210,9 @@ C<site/tags/E<lt>slugE<gt>/index.html> for each tag.
 
 sub gen_tags {
     my ($tt, $config, $all_posts) = @_;
+    my $announce = load_announce($top_dir);
     my $tags = collect_tags(@$all_posts);
-    gen_tag_pages($tt, $tags, $site_folder, $config);
+    gen_tag_pages($tt, $tags, $site_folder, $config, $announce);
 }
 
 main();

--- a/data/news/20260506-025914.txt
+++ b/data/news/20260506-025914.txt
@@ -1,6 +1,7 @@
 Date: 2026-05-06 02:59:14
 Author: Daisy Maris Fung (Open Source Hong Kong)
 Title: OSHK Meetup #99 One Step Beyond w/ Open Claw
+Tags: linux, smoke-test
 Content:
 News Feed - Source :  
 [Open Source Hong Kong - OSHK Meetup #99 One Step Beyond w/ Open Claw](https://opensource.hk/oshk-meetup-99-one-step-beyond-w-open-claw/)

--- a/data/sitegen.yaml
+++ b/data/sitegen.yaml
@@ -1,0 +1,3 @@
+site_url: https://hklug.org
+site_name: Hong Kong Linux User Group - 香港Linux用家協會(HKLUG)
+site_description: Community news and events for Linux users in Hong Kong.

--- a/docs/superpowers/plans/2026-05-19-sitegen-seo-tags-incremental.md
+++ b/docs/superpowers/plans/2026-05-19-sitegen-seo-tags-incremental.md
@@ -1,0 +1,1020 @@
+# hklug-sitegen SEO, Tag Pages & Incremental Generation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add SEO meta tags, tag-based browsing pages, and SHA-256-based incremental generation to hklug-sitegen while refactoring the monolithic `sitegen.pl` into focused Perl modules.
+
+**Architecture:** `bin/sitegen.pl` becomes a thin orchestrator that delegates to four new modules under `lib/Sitegen/`: `DataLoader` (post parsing + tag extraction), `Cache` (SHA-256 incremental skip), `SEO` (og: meta hashref), and `Tags` (tag collection + page generation). Site configuration moves from hardcoded globals into `data/sitegen.yaml`.
+
+**Tech Stack:** Perl 5, Template Toolkit (`Template`), `Digest::SHA` (core), `JSON::PP` (core), `YAML::Tiny` (needs install), `Text::Markdown::Discount` (existing).
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `data/sitegen.yaml` | Site URL, name, description config |
+| Create | `.gitignore` | Ignore generated cache + site output |
+| Create | `lib/Sitegen/DataLoader.pm` | `load_data()`, `load_announce()`, Tags: parsing |
+| Create | `lib/Sitegen/Cache.pm` | SHA-256 cache load/save/check/update |
+| Create | `lib/Sitegen/SEO.pm` | `seo_meta()` returns description + og: hashref |
+| Create | `lib/Sitegen/Tags.pm` | `collect_tags()`, `tag_slug()`, `gen_tag_pages()` |
+| Modify | `bin/sitegen.pl` | Use all modules, add `--force`, incremental archive, gen_tags |
+| Modify | `template/header.html` | Dynamic `<title>`, conditional SEO block |
+| Modify | `template/post.html` | Display tags as links |
+| Modify | `template/archive.html` | Display tags as links |
+| Create | `template/tag_list.html` | All-tags index page |
+| Create | `template/tag_page.html` | Posts for a single tag |
+| Create | `t/DataLoader.t` | Unit tests for DataLoader |
+| Create | `t/Cache.t` | Unit tests for Cache |
+| Create | `t/SEO.t` | Unit tests for SEO |
+| Create | `t/Tags.t` | Unit tests for Tags |
+
+---
+
+## Task 1: Infrastructure — install deps, config file, gitignore, lib dir
+
+**Files:**
+- Create: `data/sitegen.yaml`
+- Create: `.gitignore`
+- Create: `lib/Sitegen/` (directory)
+
+- [ ] **Step 1: Install YAML::Tiny**
+
+```bash
+sudo apt-get install -y libyaml-tiny-perl
+```
+
+Verify:
+```bash
+perl -e "use YAML::Tiny; print 'OK\n'"
+```
+Expected: `OK`
+
+- [ ] **Step 2: Create `data/sitegen.yaml`**
+
+```yaml
+site_url: https://hklug.org
+site_name: Hong Kong Linux User Group - 香港Linux用家協會(HKLUG)
+site_description: Community news and events for Linux users in Hong Kong.
+```
+
+- [ ] **Step 3: Create `lib/Sitegen/` directory**
+
+```bash
+mkdir -p lib/Sitegen
+```
+
+- [ ] **Step 4: Create `.gitignore`**
+
+```
+data/.sitegen-cache.json
+site/
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add data/sitegen.yaml .gitignore lib/
+git commit -m "chore: add sitegen.yaml config, .gitignore, lib/ directory"
+```
+
+---
+
+## Task 2: `lib/Sitegen/DataLoader.pm` — post parsing with Tags: support
+
+**Files:**
+- Create: `lib/Sitegen/DataLoader.pm`
+- Create: `t/DataLoader.t`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `t/DataLoader.t`:
+
+```perl
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 10;
+use File::Temp qw(tempdir);
+use lib 'lib';
+
+use_ok('Sitegen::DataLoader', qw(load_data load_announce));
+
+my $tmpdir = tempdir(CLEANUP => 1);
+
+# Helper: write a temp .txt file
+sub write_txt {
+    my ($dir, $name, $content) = @_;
+    open(my $fh, '>', "$dir/$name") or die $!;
+    print $fh $content;
+    close $fh;
+    return "$dir/$name";
+}
+
+# Test 1: basic fields parsed
+my $f = write_txt($tmpdir, 'test1.txt', <<'END');
+Date: 2024-01-15 18:00
+Author: Wan Leung Wong
+Title: Test Post
+Content:
+Hello **world**.
+END
+my $post = load_data($f);
+is($post->{date},   '2024-01-15 18:00', 'date parsed');
+is($post->{author}, 'Wan Leung Wong',   'author parsed');
+is($post->{title},  'Test Post',        'title parsed');
+like($post->{content}, qr/<strong>world<\/strong>|<b>world<\/b>/, 'content markdown rendered');
+
+# Test 2: no Tags: line → empty arrayref
+is(ref($post->{tags}), 'ARRAY', 'tags is arrayref');
+is(scalar @{$post->{tags}}, 0, 'no tags = empty array');
+
+# Test 3: Tags: line parsed and lowercased
+my $f2 = write_txt($tmpdir, 'test2.txt', <<'END');
+Date: 2024-02-01 10:00
+Author: Bot
+Title: Tagged Post
+Tags: Linux, Open-Source, EVENT
+Content:
+Body.
+END
+my $post2 = load_data($f2);
+is_deeply($post2->{tags}, ['linux', 'open-source', 'event'], 'tags lowercased and trimmed');
+
+# Test 4: load_announce returns most recent file
+my $topdir = "$tmpdir/top";
+mkdir $topdir;
+write_txt($topdir, '001.txt', "Date: 2024-01-01\nAuthor: A\nTitle: Old\nContent:\nOld.");
+write_txt($topdir, '002.txt', "Date: 2024-02-01\nAuthor: B\nTitle: New\nContent:\nNew.");
+my $announce = load_announce($topdir);
+is($announce->{title}, 'New', 'load_announce returns most recent file');
+
+# Test 5: comment lines skipped
+my $f3 = write_txt($tmpdir, 'test3.txt', <<'END');
+// this is a comment
+Date: 2024-03-01 09:00
+Author: Bot
+Title: With Comment
+Content:
+Body.
+END
+my $post3 = load_data($f3);
+is($post3->{date}, '2024-03-01 09:00', 'comment lines skipped');
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /path/to/hklug-sitegen
+prove -l t/DataLoader.t
+```
+
+Expected: `Can't locate Sitegen/DataLoader.pm`
+
+- [ ] **Step 3: Create `lib/Sitegen/DataLoader.pm`**
+
+```perl
+package Sitegen::DataLoader;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use Text::Markdown::Discount qw(markdown);
+
+our @EXPORT_OK = qw(load_data load_announce);
+
+sub load_data {
+    my ($filename) = @_;
+    my %post;
+    my $iscontent = 0;
+
+    open(my $fh, '<', $filename) or die "Cannot open $filename: $!";
+    while (my $line = <$fh>) {
+        next if $line =~ m|^//|;
+        if ($iscontent == 0) {
+            chomp $line;
+            if    ($line =~ m/^Date:\s*(.+)$/)   { $post{date}   = $1 }
+            elsif ($line =~ m/^Author:\s*(.+)$/)  { $post{author} = $1 }
+            elsif ($line =~ m/^Title:\s*(.+)$/)   { $post{title}  = $1 }
+            elsif ($line =~ m/^Tags:\s*(.*)$/) {
+                my $raw = $1;
+                $post{tags} = [
+                    map  { my $t = $_; $t =~ s/^\s+|\s+$//g; lc $t }
+                    grep { /\S/ }
+                    split(/,/, $raw)
+                ];
+            }
+            elsif ($line =~ m/^Content:(.*)$/) {
+                $post{content} = $1;
+                $iscontent = 1;
+            }
+        } else {
+            $post{content} .= $line;
+        }
+    }
+    close $fh;
+
+    $post{tags}    //= [];
+    $post{content}   = markdown($post{content} // '');
+    return \%post;
+}
+
+sub load_announce {
+    my ($top_dir) = @_;
+    my @filelist;
+    opendir(my $dh, $top_dir) or die "Cannot open $top_dir: $!";
+    while (my $file = readdir($dh)) {
+        push @filelist, $file if $file =~ m/\.txt$/;
+    }
+    closedir($dh);
+    my @sortlist = sort @filelist;
+    my $filename = pop @sortlist;
+    return load_data("$top_dir/$filename");
+}
+
+1;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+prove -l t/DataLoader.t
+```
+
+Expected: `All tests successful.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Sitegen/DataLoader.pm t/DataLoader.t
+git commit -m "feat: add Sitegen::DataLoader with Tags: parsing"
+```
+
+---
+
+## Task 3: `lib/Sitegen/Cache.pm` — SHA-256 incremental cache
+
+**Files:**
+- Create: `lib/Sitegen/Cache.pm`
+- Create: `t/Cache.t`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `t/Cache.t`:
+
+```perl
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 9;
+use File::Temp qw(tempdir tempfile);
+use lib 'lib';
+
+use_ok('Sitegen::Cache', qw(load_cache save_cache is_fresh update_cache));
+
+my $tmpdir = tempdir(CLEANUP => 1);
+
+# Test 1: load_cache on missing file returns empty hashref
+my $cache = load_cache("$tmpdir/nonexistent.json");
+is(ref($cache), 'HASH', 'missing cache returns hashref');
+is(scalar keys %$cache, 0, 'missing cache is empty');
+
+# Test 2: save_cache then load_cache round-trips
+my $data = { 'foo.txt' => 'abc123' };
+save_cache("$tmpdir/cache.json", $data);
+my $loaded = load_cache("$tmpdir/cache.json");
+is($loaded->{'foo.txt'}, 'abc123', 'save and load round-trip');
+
+# Test 3: corrupt cache returns empty hashref with warning
+open(my $fh, '>', "$tmpdir/bad.json") or die $!;
+print $fh "NOT JSON {{{{";
+close $fh;
+my $bad = load_cache("$tmpdir/bad.json");
+is(ref($bad), 'HASH', 'corrupt cache returns hashref');
+is(scalar keys %$bad, 0, 'corrupt cache is empty');
+
+# Test 4: update_cache + is_fresh
+my $srcfile = "$tmpdir/article.txt";
+open($fh, '>', $srcfile) or die $!;
+print $fh "Date: 2024-01-01\nContent:\nHello.";
+close $fh;
+
+my $outfile = "$tmpdir/article.html";
+open($fh, '>', $outfile) or die $!; print $fh "<p>Hello.</p>"; close $fh;
+
+my $c = {};
+is(is_fresh($c, $srcfile, $outfile), 0, 'not fresh before update_cache');
+
+update_cache($c, $srcfile);
+is(is_fresh($c, $srcfile, $outfile), 1, 'fresh after update_cache');
+
+# Test 5: is_fresh returns 0 when output file missing
+unlink $outfile;
+is(is_fresh($c, $srcfile, $outfile), 0, 'not fresh when output file missing');
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+prove -l t/Cache.t
+```
+
+Expected: `Can't locate Sitegen/Cache.pm`
+
+- [ ] **Step 3: Create `lib/Sitegen/Cache.pm`**
+
+```perl
+package Sitegen::Cache;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use Digest::SHA qw(sha256_hex);
+use JSON::PP;
+
+our @EXPORT_OK = qw(load_cache save_cache is_fresh update_cache);
+
+sub load_cache {
+    my ($cache_file) = @_;
+    return {} unless -f $cache_file;
+    open(my $fh, '<', $cache_file) or do {
+        warn "Cannot read cache file $cache_file: $!\n";
+        return {};
+    };
+    my $json = do { local $/; <$fh> };
+    close $fh;
+    my $data = eval { decode_json($json) };
+    if ($@) {
+        warn "Corrupt cache file, starting fresh: $@\n";
+        return {};
+    }
+    return $data;
+}
+
+sub save_cache {
+    my ($cache_file, $cache) = @_;
+    open(my $fh, '>', $cache_file) or die "Cannot write cache $cache_file: $!";
+    print $fh JSON::PP->new->pretty->encode($cache);
+    close $fh;
+}
+
+sub _file_sha256 {
+    my ($file) = @_;
+    open(my $fh, '<', $file) or die "Cannot read $file: $!";
+    my $content = do { local $/; <$fh> };
+    close $fh;
+    return sha256_hex($content);
+}
+
+sub _basename { (split m{/}, $_[0])[-1] }
+
+sub is_fresh {
+    my ($cache, $src_file, $out_file) = @_;
+    return 0 unless -f $out_file;
+    my $key = _basename($src_file);
+    return 0 unless exists $cache->{$key};
+    return $cache->{$key} eq _file_sha256($src_file) ? 1 : 0;
+}
+
+sub update_cache {
+    my ($cache, $src_file) = @_;
+    $cache->{_basename($src_file)} = _file_sha256($src_file);
+}
+
+1;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+prove -l t/Cache.t
+```
+
+Expected: `All tests successful.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Sitegen/Cache.pm t/Cache.t
+git commit -m "feat: add Sitegen::Cache with SHA-256 incremental skip"
+```
+
+---
+
+## Task 4: `lib/Sitegen/SEO.pm` — og: meta hashref
+
+**Files:**
+- Create: `lib/Sitegen/SEO.pm`
+- Create: `t/SEO.t`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `t/SEO.t`:
+
+```perl
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 8;
+use lib 'lib';
+
+use_ok('Sitegen::SEO', qw(seo_meta));
+
+my $config = {
+    site_url         => 'https://hklug.org',
+    site_name        => 'HKLUG',
+    site_description => 'Linux users in HK.',
+};
+
+# Test 1: og_url constructed correctly
+my $post = { title => 'My Post', content => '<p>Hello world.</p>' };
+my $seo  = seo_meta($post, $config, '/archive/20240101-120000.html');
+is($seo->{og_url}, 'https://hklug.org/archive/20240101-120000.html', 'og_url correct');
+
+# Test 2: og_title from post title
+is($seo->{og_title}, 'My Post', 'og_title from post title');
+
+# Test 3: HTML stripped from description
+is($seo->{description}, 'Hello world.', 'HTML stripped from description');
+
+# Test 4: description same as og_description
+is($seo->{description}, $seo->{og_description}, 'description == og_description');
+
+# Test 5: long content truncated to 160 chars
+my $long = 'A' x 200;
+my $seo2 = seo_meta({ title => 'T', content => $long }, $config, '/');
+is(length($seo2->{description}), 160, 'description truncated to 160 chars');
+
+# Test 6: empty content falls back to site_description
+my $seo3 = seo_meta({ title => 'T', content => '' }, $config, '/');
+is($seo3->{description}, 'Linux users in HK.', 'empty content uses site_description');
+
+# Test 7: trailing slash removed from site_url
+my $cfg2 = { %$config, site_url => 'https://hklug.org/' };
+my $seo4 = seo_meta($post, $cfg2, '/archive/x.html');
+is($seo4->{og_url}, 'https://hklug.org/archive/x.html', 'trailing slash stripped from site_url');
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+prove -l t/SEO.t
+```
+
+Expected: `Can't locate Sitegen/SEO.pm`
+
+- [ ] **Step 3: Create `lib/Sitegen/SEO.pm`**
+
+```perl
+package Sitegen::SEO;
+
+use strict;
+use warnings;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(seo_meta);
+
+sub seo_meta {
+    my ($post, $config, $url_path) = @_;
+
+    my $content = $post->{content} // '';
+    (my $plain = $content) =~ s/<[^>]+>//g;
+    $plain =~ s/\s+/ /g;
+    $plain =~ s/^\s+|\s+$//g;
+
+    my $description = length($plain) > 0
+        ? substr($plain, 0, 160)
+        : ($config->{site_description} // '');
+
+    (my $base = $config->{site_url} // '') =~ s|/$||;
+
+    return {
+        description    => $description,
+        og_title       => $post->{title} // $config->{site_name} // '',
+        og_description => $description,
+        og_url         => "$base$url_path",
+    };
+}
+
+1;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+prove -l t/SEO.t
+```
+
+Expected: `All tests successful.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Sitegen/SEO.pm t/SEO.t
+git commit -m "feat: add Sitegen::SEO for og: meta generation"
+```
+
+---
+
+## Task 5: `lib/Sitegen/Tags.pm` — tag collection and page generation
+
+**Files:**
+- Create: `lib/Sitegen/Tags.pm`
+- Create: `t/Tags.t`
+
+Note: `gen_tag_pages()` uses Template Toolkit, so it is tested by verifying output file existence and content in the integration test (Task 7). Unit tests here cover `collect_tags()` and `tag_slug()` only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `t/Tags.t`:
+
+```perl
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 8;
+use lib 'lib';
+
+use_ok('Sitegen::Tags', qw(collect_tags tag_slug));
+
+# Test 1: tag_slug lowercases and replaces spaces
+is(tag_slug('Open Source'), 'open-source', 'spaces become hyphens');
+is(tag_slug('Linux'),       'linux',       'already lowercase unchanged');
+is(tag_slug('AI & ML'),    'ai-&-ml',     'non-space chars preserved');
+
+# Test 2: collect_tags builds tag->posts map
+my @posts = (
+    { title => 'Post A', tags => ['linux', 'event'] },
+    { title => 'Post B', tags => ['linux'] },
+    { title => 'Post C', tags => ['event', 'open-source'] },
+    { title => 'Post D', tags => [] },
+);
+my $tags = collect_tags(@posts);
+is(ref($tags), 'HASH', 'collect_tags returns hashref');
+is(scalar @{$tags->{linux}}, 2, 'linux has 2 posts');
+is(scalar @{$tags->{event}}, 2, 'event has 2 posts');
+is(scalar @{$tags->{'open-source'}}, 1, 'open-source has 1 post');
+ok(!exists $tags->{''}, 'empty tags not included');
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+prove -l t/Tags.t
+```
+
+Expected: `Can't locate Sitegen/Tags.pm`
+
+- [ ] **Step 3: Create `lib/Sitegen/Tags.pm`**
+
+```perl
+package Sitegen::Tags;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use File::Path qw(make_path);
+
+our @EXPORT_OK = qw(collect_tags tag_slug gen_tag_pages);
+
+sub tag_slug {
+    my ($tag) = @_;
+    (my $slug = lc $tag) =~ s/\s+/-/g;
+    return $slug;
+}
+
+sub collect_tags {
+    my (@posts) = @_;
+    my %tags;
+    for my $post (@posts) {
+        for my $tag (@{$post->{tags} // []}) {
+            next unless defined $tag && length $tag;
+            push @{$tags{$tag}}, $post;
+        }
+    }
+    return \%tags;
+}
+
+sub gen_tag_pages {
+    my ($tt, $tags, $site_folder, $config) = @_;
+    my $tags_folder = "$site_folder/tags";
+    make_path($tags_folder) unless -d $tags_folder;
+
+    my @tag_list = map {
+        { name => $_, slug => tag_slug($_), count => scalar @{$tags->{$_}} }
+    } sort keys %$tags;
+
+    $tt->process('tag_list.html',
+        { title => $config->{site_name} . ' > Tags', tag_list => \@tag_list },
+        "$tags_folder/index.html"
+    ) || die $tt->error();
+
+    for my $tag (keys %$tags) {
+        my $slug    = tag_slug($tag);
+        my $tag_dir = "$tags_folder/$slug";
+        make_path($tag_dir) unless -d $tag_dir;
+        $tt->process('tag_page.html',
+            {
+                title => $config->{site_name} . " > Tag: $tag",
+                tag   => $tag,
+                slug  => $slug,
+                posts => $tags->{$tag},
+            },
+            "$tag_dir/index.html"
+        ) || die $tt->error();
+    }
+}
+
+1;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+prove -l t/Tags.t
+```
+
+Expected: `All tests successful.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Sitegen/Tags.pm t/Tags.t
+git commit -m "feat: add Sitegen::Tags for tag collection and page generation"
+```
+
+---
+
+## Task 6: Template updates — SEO block, tag display, new tag templates
+
+**Files:**
+- Modify: `template/header.html` (lines 9, 12-13)
+- Modify: `template/post.html` (after line 13)
+- Modify: `template/archive.html` (uses post.html via PROCESS — no change needed; post.html handles it)
+- Create: `template/tag_list.html`
+- Create: `template/tag_page.html`
+
+- [ ] **Step 1: Update `template/header.html`**
+
+Replace lines 9–13 (static title + closing `</head>` area):
+
+**Before (line 9):**
+```html
+    <title>Hong Kong Linux User Group (HKLUG)</title>
+    <link rel="stylesheet" href="/css/foundation.css" />
+    <link rel="stylesheet" href="/css/main.css" />
+    <script src="/js/vendor/modernizr.js"></script>
+  </head>
+```
+
+**After:**
+```html
+    <title>[% title %]</title>
+    [% IF seo %]
+    <meta name="description" content="[% seo.description | html %]" />
+    <meta property="og:title" content="[% seo.og_title | html %]" />
+    <meta property="og:description" content="[% seo.og_description | html %]" />
+    <meta property="og:url" content="[% seo.og_url %]" />
+    <link rel="canonical" href="[% seo.og_url %]" />
+    [% END %]
+    <link rel="stylesheet" href="/css/foundation.css" />
+    <link rel="stylesheet" href="/css/main.css" />
+    <script src="/js/vendor/modernizr.js"></script>
+  </head>
+```
+
+- [ ] **Step 2: Update `template/post.html`** — add tag links after the `<hr />`
+
+**Before (line 13):**
+```html
+      </article>
+      <hr />
+
+  <!-- post end -->
+```
+
+**After:**
+```html
+      [% IF post.tags.size %]
+      <p class="post-tags">Tags:
+        [% FOREACH tag = post.tags %]<a href="/tags/[% tag | uri %]/">[% tag | html %]</a>[% UNLESS loop.last %], [% END %][% END %]
+      </p>
+      [% END %]
+      </article>
+      <hr />
+
+  <!-- post end -->
+```
+
+- [ ] **Step 3: Create `template/tag_list.html`**
+
+```html
+[% WRAPPER frame.html %]
+  <h2>All Tags</h2>
+  [% IF tag_list.size %]
+  <ul class="tag-list">
+    [% FOREACH t = tag_list %]
+    <li><a href="/tags/[% t.slug | uri %]/">[% t.name | html %]</a> ([% t.count %])</li>
+    [% END %]
+  </ul>
+  [% ELSE %]
+  <p>No tags yet.</p>
+  [% END %]
+[% END %]
+```
+
+- [ ] **Step 4: Create `template/tag_page.html`**
+
+```html
+[% WRAPPER frame.html %]
+  <h2>Posts tagged: [% tag | html %]</h2>
+  [% FOREACH post = posts %]
+    [% PROCESS post.html %]
+  [% END %]
+  <p><a href="/tags/">← All Tags</a></p>
+[% END %]
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add template/header.html template/post.html template/tag_list.html template/tag_page.html
+git commit -m "feat: update templates for SEO meta block and tag display"
+```
+
+---
+
+## Task 7: Refactor `bin/sitegen.pl` — use all modules, --force, incremental, tags
+
+**Files:**
+- Modify: `bin/sitegen.pl` (full rewrite)
+
+- [ ] **Step 1: Replace the full content of `bin/sitegen.pl`**
+
+```perl
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Getopt::Long;
+use Template;
+use YAML::Tiny;
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use Sitegen::DataLoader qw(load_data load_announce);
+use Sitegen::Cache      qw(load_cache save_cache is_fresh update_cache);
+use Sitegen::SEO        qw(seo_meta);
+use Sitegen::Tags       qw(collect_tags tag_slug gen_tag_pages);
+
+my $force = 0;
+GetOptions('force' => \$force);
+
+our $base_dir       = "$Bin/..";
+our $data_dir       = "$base_dir/data";
+our $top_dir        = "$data_dir/top";
+our $news_dir       = "$data_dir/news";
+our $site_folder    = "$base_dir/site";
+our $archive_folder = "$site_folder/archive";
+our $cache_file     = "$data_dir/.sitegen-cache.json";
+our $config_file    = "$data_dir/sitegen.yaml";
+
+sub load_config {
+    die "Missing config file: $config_file\n" unless -f $config_file;
+    my $yaml = YAML::Tiny->read($config_file)
+        or die "Cannot parse $config_file: " . YAML::Tiny->errstr . "\n";
+    return $yaml->[0];
+}
+
+sub main {
+    my $config = load_config();
+    my $cache  = $force ? {} : load_cache($cache_file);
+
+    my $tt = Template->new({
+        INCLUDE_PATH => "$base_dir/template",
+        INTERPOLATE  => 0,
+    }) || die "$Template::ERROR\n";
+
+    gen_home($tt, $config);
+    gen_pages($tt, $config);
+    my $all_posts = gen_archive($tt, $config, $cache);
+    gen_tags($tt, $config, $all_posts);
+
+    save_cache($cache_file, $cache);
+}
+
+sub gen_home {
+    my ($tt, $config) = @_;
+    my @filelist;
+    opendir(my $dh, $news_dir) or die $!;
+    while (my $file = readdir($dh)) { push @filelist, $file if $file =~ m/\.txt$/ }
+    closedir($dh);
+    my @sortlist = sort @filelist;
+    my $total    = scalar @sortlist;
+
+    my @news_posts;
+    for my $i (1..5) {
+        last if ($total - $i < 0);
+        push @news_posts, load_data("$news_dir/$sortlist[$total - $i]");
+    }
+
+    my $announce = load_announce($top_dir);
+    my $seo_post = { title => $config->{site_name} . ' > News', content => '' };
+    $tt->process('news.html', {
+        title    => $config->{site_name} . ' > News',
+        news     => \@news_posts,
+        announce => $announce,
+        seo      => seo_meta($seo_post, $config, '/'),
+    }, "$site_folder/index.html") || die $tt->error();
+}
+
+sub gen_pages {
+    my ($tt, $config) = @_;
+    my @filelist;
+    opendir(my $dh, $data_dir) or die $!;
+    while (my $file = readdir($dh)) { push @filelist, $file if $file =~ m/\.txt$/ }
+    closedir($dh);
+
+    for my $file (@filelist) {
+        my $post     = load_data("$data_dir/$file");
+        my $announce = load_announce($top_dir);
+        (my $newfile = $file) =~ s/\.txt$/.html/;
+        $tt->process('page.html', {
+            title    => $config->{site_name} . ' > ' . $post->{title},
+            post     => $post,
+            announce => $announce,
+            seo      => seo_meta($post, $config, "/$newfile"),
+        }, "$site_folder/$newfile") || die $tt->error();
+    }
+}
+
+# Returns arrayref of all posts (newest-first) for use by gen_tags
+sub gen_archive {
+    my ($tt, $config, $cache) = @_;
+    my @filelist;
+    opendir(my $dh, $news_dir) or die $!;
+    while (my $file = readdir($dh)) { push @filelist, $file if $file =~ m/\.txt$/ }
+    closedir($dh);
+
+    my @sortlist = sort @filelist;
+    my $total    = scalar @sortlist;
+    my (@allnews, $count);
+    $count = 0;
+
+    for my $file (@sortlist) {
+        (my $newfile = $file) =~ s/\.txt$/.html/;
+        my $srcfile = "$news_dir/$file";
+        my $outfile = "$archive_folder/$newfile";
+
+        my $post = load_data($srcfile);
+        $post->{url} = "/archive/$newfile";
+        push @allnews, $post;
+
+        if (!$force && is_fresh($cache, $srcfile, $outfile)) {
+            print "SKIP $file\n";
+            $count++;
+            next;
+        }
+
+        my $preindex  = ($count + 1 >= $total) ? $count     : $count + 1;
+        my $nextindex = ($count - 1 < 0)       ? 0          : $count - 1;
+
+        (my $prevfile  = $sortlist[$preindex])  =~ s/\.txt$/.html/;
+        (my $nextfile2 = $sortlist[$nextindex]) =~ s/\.txt$/.html/;
+        (my $startfile = $sortlist[$total - 1]) =~ s/\.txt$/.html/;
+        (my $endfile   = $sortlist[0])          =~ s/\.txt$/.html/;
+
+        $tt->process('archive.html', {
+            title => $config->{site_name} . ' > Archive > ' . $post->{title},
+            post  => $post,
+            url   => {
+                front     => "/archive/$startfile",
+                end       => "/archive/$endfile",
+                prev      => "/archive/$prevfile",
+                next      => "/archive/$nextfile2",
+                home      => "/archive/",
+                hometitle => "Archive",
+            },
+            seo => seo_meta($post, $config, "/archive/$newfile"),
+        }, $outfile) || die $tt->error();
+
+        update_cache($cache, $srcfile);
+        $count++;
+    }
+
+    # Archive list — always regenerate
+    my @reversed  = reverse @allnews;
+    my $announce  = load_announce($top_dir);
+    my $seo_post  = { title => $config->{site_name} . ' > Archive', content => '' };
+    $tt->process('archive_list.html', {
+        title     => $config->{site_name} . ' > Archive',
+        pagetitle => 'Archives',
+        news      => \@reversed,
+        announce  => $announce,
+        seo       => seo_meta($seo_post, $config, '/archive/'),
+    }, "$archive_folder/index.html") || die $tt->error();
+
+    return [reverse @allnews];  # newest-first for tags
+}
+
+sub gen_tags {
+    my ($tt, $config, $all_posts) = @_;
+    my $tags = collect_tags(@$all_posts);
+    gen_tag_pages($tt, $tags, $site_folder, $config);
+}
+
+main();
+```
+
+- [ ] **Step 2: Run all unit tests to verify nothing broken**
+
+```bash
+prove -l t/
+```
+
+Expected: `All tests successful.` (DataLoader, Cache, SEO, Tags)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bin/sitegen.pl
+git commit -m "refactor: rewrite sitegen.pl using Sitegen:: modules with --force and incremental cache"
+```
+
+---
+
+## Task 8: End-to-end smoke test
+
+No new files — this task verifies the full system works.
+
+- [ ] **Step 1: Run sitegen for the first time (full build)**
+
+```bash
+cd /path/to/hklug-sitegen
+perl bin/sitegen.pl
+```
+
+Expected: No `SKIP` lines. `site/index.html`, `site/archive/*.html`, `site/tags/index.html` all created. `data/.sitegen-cache.json` written.
+
+- [ ] **Step 2: Run sitegen again (incremental — all unchanged)**
+
+```bash
+perl bin/sitegen.pl 2>&1 | grep -c "^SKIP"
+```
+
+Expected: output is `358` (or however many `.txt` files exist) — all archive pages skipped.
+
+- [ ] **Step 3: Verify SEO tags in a generated archive page**
+
+```bash
+grep -m1 "og:title" site/archive/*.html
+```
+
+Expected: `<meta property="og:title" content="..." />`
+
+- [ ] **Step 4: Add a tag to a news file and verify tag page**
+
+```bash
+# Edit the most recent news file to add a Tags: line
+RECENT=$(ls data/news/*.txt | sort | tail -1)
+# Insert "Tags: linux, test-tag" before "Content:" line
+sed -i '/^Content:/i Tags: linux, test-tag' "$RECENT"
+perl bin/sitegen.pl
+```
+
+Expected: `site/tags/linux/index.html` and `site/tags/test-tag/index.html` both exist. `site/tags/index.html` lists both tags.
+
+- [ ] **Step 5: Verify `--force` regenerates everything**
+
+```bash
+perl bin/sitegen.pl --force 2>&1 | grep -c "^SKIP"
+```
+
+Expected: `0` — no pages skipped.
+
+- [ ] **Step 6: Run all unit tests**
+
+```bash
+prove -l t/
+```
+
+Expected: `All tests successful.`
+
+- [ ] **Step 7: Push to origin**
+
+```bash
+git push origin master
+```
+
+---
+
+## Post-implementation checklist
+
+- [ ] `data/.sitegen-cache.json` is in `.gitignore` and not committed
+- [ ] `site/` output is gitignored (or already was)
+- [ ] All 4 unit test files pass with `prove -l t/`
+- [ ] `site/tags/index.html` lists all tags
+- [ ] A generated archive page contains `<meta property="og:title">`
+- [ ] Second run with no changes skips all archive pages

--- a/docs/superpowers/specs/2026-05-19-sitegen-seo-tags-incremental-design.md
+++ b/docs/superpowers/specs/2026-05-19-sitegen-seo-tags-incremental-design.md
@@ -1,0 +1,246 @@
+# hklug-sitegen: SEO, Tag Pages, and Incremental Generation
+
+**Date:** 2026-05-19  
+**Status:** Approved
+
+---
+
+## Problem
+
+The hklug-sitegen generator (Perl + Template Toolkit) has three gaps:
+
+1. **No SEO** — `<head>` has no `<meta name="description">`, no Open Graph tags, no canonical URL.
+2. **No tag pages** — posts have no tag taxonomy; there is no way to browse posts by topic.
+3. **Full regeneration every run** — with 358+ news files, every run rebuilds every page. As the archive grows this becomes slow.
+
+---
+
+## Approach
+
+Enhance the generator in Perl, extracting concerns into modules under `lib/Sitegen/`. `bin/sitegen.pl` becomes a thin orchestrator. Four modules are introduced.
+
+---
+
+## Module Structure
+
+```
+bin/sitegen.pl               # thin orchestrator
+lib/Sitegen/
+  DataLoader.pm              # load_data(), load_announce(), Tags: parsing
+  Cache.pm                   # SHA-256 hash cache
+  SEO.pm                     # seo_meta() — description + og: hashref
+  Tags.pm                    # collect_tags(), gen_tag_pages()
+data/sitegen.yaml            # site configuration (new)
+data/.sitegen-cache.json     # generated cache (gitignored)
+template/
+  header.html                # updated: conditional [% IF seo %] block
+  tag_list.html              # new: all-tags index
+  tag_page.html              # new: posts for a single tag
+site/tags/                   # new: generated tag pages
+```
+
+### `lib/Sitegen/DataLoader.pm`
+
+Moves existing `load_data()` and `load_announce()` from `sitegen.pl` into this module. Adds `Tags:` line parsing.
+
+**`Tags:` format** — optional line before `Content:`, comma-separated:
+```
+Tags: linux, open-source, event
+```
+Files without a `Tags:` line get `$post->{tags} = []` (backward compatible). Tags are trimmed and lowercased for consistency.
+
+### `lib/Sitegen/Cache.pm`
+
+```perl
+load_cache($cache_file)        # returns hashref {filename => sha256hex}
+save_cache($cache_file, $cache)
+is_fresh($cache, $src_file, $out_file)
+  # true if: hash matches AND $out_file exists on disk
+update_cache($cache, $src_file)  # compute and store hash
+```
+
+Cache file: `data/.sitegen-cache.json` (JSON, human-readable).
+
+### `lib/Sitegen/SEO.pm`
+
+```perl
+seo_meta($post, $config, $url_path)
+```
+
+`$url_path` is the site-relative path for the page (e.g. `/archive/20230101-120000.html`). For index pages pass `/` or `/archive/`.
+
+Returns a hashref:
+```perl
+{
+  description    => "First 160 chars of plain text, HTML stripped",
+  og_title       => $post->{title},
+  og_description => "same as description",
+  og_url         => "$config->{site_url}$url_path",
+}
+```
+
+For index/home pages, `$post->{title}` is the generic page title and `$config->{site_description}` is used as fallback when content is empty.
+
+HTML stripping: remove all `<...>` tags with a regex before truncating to 160 chars.
+
+### `lib/Sitegen/Tags.pm`
+
+```perl
+collect_tags(@posts)
+  # returns { 'linux' => [$post1, $post2, ...], ... }
+  # posts sorted newest-first within each tag
+
+gen_tag_pages($tt, $tags_hashref, $site_folder, $config)
+  # generates:
+  #   site/tags/index.html          (tag_list.html template)
+  #   site/tags/<tag>/index.html    (tag_page.html template per tag)
+```
+
+Tag names in URLs are lowercased and spaces replaced with hyphens (e.g. `open source` → `open-source`).
+
+---
+
+## Configuration File
+
+`data/sitegen.yaml`:
+```yaml
+site_url: https://hklug.org
+site_name: Hong Kong Linux User Group - 香港Linux用家協會(HKLUG)
+site_description: Community news and events for Linux users in Hong Kong.
+```
+
+Parsed at startup using `YAML::Tiny` (pure Perl, no XS dependency). Values passed through to all generators as `$config` hashref.
+
+---
+
+## Data Format — `Tags:` Field
+
+The `.txt` format gains one optional header field:
+
+```
+Date: 2024-01-15 18:00
+Author: Wan Leung Wong
+Title: Monthly Open Source Workshop
+Tags: linux, event, open-source
+Content:
+<body HTML>
+```
+
+`Tags:` must appear in the header section (before `Content:`). Parsing: split on `,`, trim whitespace, lowercase. Tags may contain letters, digits, hyphens, spaces.
+
+---
+
+## SEO — Template Changes
+
+`template/header.html` updated — `<title>` is now dynamic and a conditional SEO block is added:
+
+```html
+<title>[% title %]</title>
+[% IF seo %]
+<meta name="description" content="[% seo.description %]" />
+<meta property="og:title" content="[% seo.og_title %]" />
+<meta property="og:description" content="[% seo.og_description %]" />
+<meta property="og:url" content="[% seo.og_url %]" />
+<link rel="canonical" href="[% seo.og_url %]" />
+[% END %]
+```
+
+All page-generating calls in `sitegen.pl` pass a `seo` key in `$vars`.
+
+---
+
+## Tag Display — Post Templates
+
+`template/post.html` updated to show tags as links (only when `$post->{tags}` is non-empty):
+
+```html
+[% IF post.tags.size %]
+<p class="tags">
+  Tags:
+  [% FOREACH tag = post.tags %]
+    <a href="/tags/[% tag %]/">[% tag %]</a>[% UNLESS loop.last %],[% END %]
+  [% END %]
+</p>
+[% END %]
+```
+
+Same change applied to `template/archive.html`.
+
+---
+
+## Incremental Generation
+
+### Cache Logic
+
+```
+startup:
+  load cache from data/.sitegen-cache.json (empty hash if missing)
+
+for each archive page (individual article .html):
+  if --force OR NOT is_fresh(cache, src.txt, site/archive/post.html):
+    generate page
+    update cache entry
+  else:
+    skip (print "SKIP <filename>")
+
+index pages (site/index.html, site/archive/index.html, site/tags/**):
+  ALWAYS regenerate — they are fast and depend on all articles
+
+shutdown:
+  save updated cache to data/.sitegen-cache.json
+```
+
+### `--force` Flag
+
+```bash
+perl bin/sitegen.pl [--force]
+```
+
+`--force` clears the in-memory cache before processing, ensuring every page is regenerated. Cache is then fully written out at the end.
+
+### Cache File Format
+
+```json
+{
+  "20120717-182938.txt": "e3b0c44298fc1c149afb...",
+  "20240115-180000.txt": "a9f8d2c4b1e7..."
+}
+```
+
+`data/.sitegen-cache.json` is added to `.gitignore`.
+
+---
+
+## File Generation Summary
+
+| Output | Template | Incremental? |
+|--------|----------|-------------|
+| `site/index.html` | `news.html` | No (always) |
+| `site/about.html` etc. | `page.html` | No (always) |
+| `site/archive/<post>.html` | `archive.html` | **Yes** |
+| `site/archive/index.html` | `archive_list.html` | No (always) |
+| `site/tags/index.html` | `tag_list.html` | No (always) |
+| `site/tags/<tag>/index.html` | `tag_page.html` | No (always) |
+
+---
+
+## Error Handling
+
+- Missing `data/sitegen.yaml` → die with clear message.
+- Malformed `Tags:` line (e.g. invalid chars) → warn and skip the bad entry; don't crash.
+- Cache file unreadable or corrupt JSON → warn and proceed with empty cache (full rebuild).
+- `site/tags/` directory created automatically if absent.
+
+---
+
+## Testing
+
+Manual smoke test:
+1. `perl bin/sitegen.pl` — first run generates all pages; cache written.
+2. `perl bin/sitegen.pl` — second run skips all unchanged archive pages (verify "SKIP" log lines).
+3. Touch one `.txt` file (or change its content); re-run — only that page regenerates.
+4. `perl bin/sitegen.pl --force` — all pages regenerate.
+5. Add `Tags: linux, event` to a `.txt`; verify `/tags/linux/index.html` lists it.
+6. Verify `<meta property="og:title">` present in generated archive page.
+
+Unit tests (optional Perl `Test::More`): `Cache.pm` hash logic, `SEO.pm` HTML stripping + truncation, `DataLoader.pm` tag parsing.

--- a/lib/Sitegen/Cache.pm
+++ b/lib/Sitegen/Cache.pm
@@ -1,0 +1,81 @@
+package Sitegen::Cache;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use Digest::SHA qw(sha256_hex);
+use JSON::PP;
+
+our @EXPORT_OK = qw(load_cache save_cache is_fresh update_cache);
+
+sub load_cache {
+    my ($cache_file) = @_;
+    return {} unless -f $cache_file;
+    open(my $fh, '<', $cache_file) or do {
+        warn "Cannot read cache file $cache_file: $!\n";
+        return {};
+    };
+    my $json = do { local $/; <$fh> };
+    close $fh;
+    my $data = eval { decode_json($json) };
+    if ($@) {
+        warn "Corrupt cache file, starting fresh: $@\n";
+        return {};
+    }
+    return $data;
+}
+
+sub save_cache {
+    my ($cache_file, $cache) = @_;
+    open(my $fh, '>', $cache_file) or die "Cannot write cache $cache_file: $!";
+    print $fh JSON::PP->new->pretty->encode($cache);
+    close $fh;
+}
+
+sub _file_sha256 {
+    my ($file) = @_;
+    open(my $fh, '<', $file) or die "Cannot read $file: $!";
+    my $content = do { local $/; <$fh> };
+    close $fh;
+    return sha256_hex($content);
+}
+
+sub _basename { (split m{/}, $_[0])[-1] }
+
+sub is_fresh {
+    my ($cache, $src_file, $out_file) = @_;
+    return 0 unless -f $out_file;
+    my $key = _basename($src_file);
+    return 0 unless exists $cache->{$key};
+    return $cache->{$key} eq _file_sha256($src_file) ? 1 : 0;
+}
+
+sub update_cache {
+    my ($cache, $src_file) = @_;
+    $cache->{_basename($src_file)} = _file_sha256($src_file);
+}
+
+=head1 NAME
+
+Sitegen::Cache - SHA-256 incremental cache for sitegen
+
+=head1 SYNOPSIS
+
+  use Sitegen::Cache qw(load_cache save_cache is_fresh update_cache);
+
+  my $cache = load_cache('data/.sitegen-cache.json');
+  unless (is_fresh($cache, $src_file, $out_file)) {
+      # regenerate $out_file ...
+      update_cache($cache, $src_file);
+  }
+  save_cache('data/.sitegen-cache.json', $cache);
+
+=head1 DESCRIPTION
+
+Manages a JSON file mapping source .txt filenames to their SHA-256 hashes.
+C<is_fresh()> returns true only when the hash matches AND the output file exists.
+C<update_cache()> stores the current hash for a source file.
+
+=cut
+
+1;

--- a/lib/Sitegen/Cache.pm
+++ b/lib/Sitegen/Cache.pm
@@ -3,7 +3,8 @@ package Sitegen::Cache;
 use strict;
 use warnings;
 use Exporter 'import';
-use Digest::SHA qw(sha256_hex);
+use Digest::SHA;
+use File::Basename qw(basename);
 use JSON::PP;
 
 our @EXPORT_OK = qw(load_cache save_cache is_fresh update_cache);
@@ -27,32 +28,38 @@ sub load_cache {
 
 sub save_cache {
     my ($cache_file, $cache) = @_;
-    open(my $fh, '>', $cache_file) or die "Cannot write cache $cache_file: $!";
+    my $tmp = "$cache_file.tmp.$$";
+    open(my $fh, '>', $tmp) or die "Cannot write cache $tmp: $!";
     print $fh JSON::PP->new->pretty->encode($cache);
     close $fh;
+    rename($tmp, $cache_file) or do {
+        unlink $tmp;
+        die "Cannot rename $tmp to $cache_file: $!";
+    };
 }
 
 sub _file_sha256 {
     my ($file) = @_;
-    open(my $fh, '<', $file) or die "Cannot read $file: $!";
-    my $content = do { local $/; <$fh> };
+    open(my $fh, '<:raw', $file) or die "Cannot read $file: $!";
+    my $sha = Digest::SHA->new(256);
+    $sha->addfile($fh);
     close $fh;
-    return sha256_hex($content);
+    return $sha->hexdigest;
 }
-
-sub _basename { (split m{/}, $_[0])[-1] }
 
 sub is_fresh {
     my ($cache, $src_file, $out_file) = @_;
-    return 0 unless -f $out_file;
-    my $key = _basename($src_file);
+    return 0 unless -f $out_file && -f $src_file;
+    my $key = basename($src_file);
     return 0 unless exists $cache->{$key};
-    return $cache->{$key} eq _file_sha256($src_file) ? 1 : 0;
+    my $sha = eval { _file_sha256($src_file) };
+    return 0 if $@;
+    return $cache->{$key} eq $sha ? 1 : 0;
 }
 
 sub update_cache {
     my ($cache, $src_file) = @_;
-    $cache->{_basename($src_file)} = _file_sha256($src_file);
+    $cache->{basename($src_file)} = _file_sha256($src_file);
 }
 
 =head1 NAME

--- a/lib/Sitegen/Cache.pm
+++ b/lib/Sitegen/Cache.pm
@@ -31,7 +31,10 @@ sub save_cache {
     my $tmp = "$cache_file.tmp.$$";
     open(my $fh, '>', $tmp) or die "Cannot write cache $tmp: $!";
     print $fh JSON::PP->new->pretty->encode($cache);
-    close $fh;
+    close $fh or do {
+        unlink $tmp;
+        die "Write error flushing $tmp: $!";
+    };
     rename($tmp, $cache_file) or do {
         unlink $tmp;
         die "Cannot rename $tmp to $cache_file: $!";

--- a/lib/Sitegen/DataLoader.pm
+++ b/lib/Sitegen/DataLoader.pm
@@ -23,11 +23,19 @@ sub load_data {
             elsif ($line =~ m/^Title:\s*(.+)$/)   { $post{title}  = $1 }
             elsif ($line =~ m/^Tags:\s*(.*)$/) {
                 my $raw = $1;
-                $post{tags} = [
+                my @raw_tags =
                     map  { my $t = $_; $t =~ s/^\s+|\s+$//g; lc $t }
                     grep { /\S/ }
-                    split(/,/, $raw)
-                ];
+                    split(/,/, $raw);
+                my @valid_tags;
+                for my $t (@raw_tags) {
+                    if ($t =~ m{[/\\]|\.\.}) {
+                        warn "Skipping unsafe tag '$t' in $filename\n";
+                    } else {
+                        push @valid_tags, $t;
+                    }
+                }
+                $post{tags} = \@valid_tags;
             }
             elsif ($line =~ m/^Content:(.*)$/) {
                 $post{content} = $1;

--- a/lib/Sitegen/DataLoader.pm
+++ b/lib/Sitegen/DataLoader.pm
@@ -82,7 +82,7 @@ Parses hklug-sitegen article files with the following format:
   Content:
   Article body in Markdown format.
 
-Comments prefixed with C<//>are stripped from the header section only.
+Comments prefixed with C<//> are stripped from the header section only.
 The content body is parsed as Markdown and returned as HTML.
 
 =cut

--- a/lib/Sitegen/DataLoader.pm
+++ b/lib/Sitegen/DataLoader.pm
@@ -2,6 +2,7 @@ package Sitegen::DataLoader;
 
 use strict;
 use warnings;
+use utf8;
 use Exporter 'import';
 use Text::Markdown::Discount qw(markdown);
 
@@ -10,12 +11,12 @@ our @EXPORT_OK = qw(load_data load_announce);
 sub load_data {
     my ($filename) = @_;
     my %post;
-    my $iscontent = 0;
+    my $in_content = 0;
 
-    open(my $fh, '<', $filename) or die "Cannot open $filename: $!";
+    open(my $fh, '<:encoding(UTF-8)', $filename) or die "Cannot open $filename: $!";
     while (my $line = <$fh>) {
-        next if $line =~ m|^//|;
-        if ($iscontent == 0) {
+        if ($in_content == 0) {
+            next if $line =~ m|^//|;
             chomp $line;
             if    ($line =~ m/^Date:\s*(.+)$/)   { $post{date}   = $1 }
             elsif ($line =~ m/^Author:\s*(.+)$/)  { $post{author} = $1 }
@@ -30,7 +31,7 @@ sub load_data {
             }
             elsif ($line =~ m/^Content:(.*)$/) {
                 $post{content} = $1;
-                $iscontent = 1;
+                $in_content = 1;
             }
         } else {
             $post{content} .= $line;
@@ -51,9 +52,39 @@ sub load_announce {
         push @filelist, $file if $file =~ m/\.txt$/;
     }
     closedir($dh);
-    my @sortlist = sort @filelist;
-    my $filename = pop @sortlist;
+    die "No .txt files found in $top_dir\n" unless @filelist;
+    my $filename = (sort @filelist)[-1];
     return load_data("$top_dir/$filename");
 }
+
+=head1 NAME
+
+Sitegen::DataLoader - Parse hklug-sitegen .txt article files
+
+=head1 SYNOPSIS
+
+  use Sitegen::DataLoader qw(load_data load_announce);
+
+  my $post = load_data('/path/to/article.txt');
+  # Returns hashref with keys: date, author, title, tags (arrayref), content (HTML)
+
+  my $latest = load_announce('/path/to/top/');
+  # Returns the lexicographically last .txt file parsed as a post
+
+=head1 DESCRIPTION
+
+Parses hklug-sitegen article files with the following format:
+
+  Date: 2024-01-15
+  Author: Your Name
+  Title: Article Title
+  Tags: tag1, tag2
+  Content:
+  Article body in Markdown format.
+
+Comments prefixed with C<//>are stripped from the header section only.
+The content body is parsed as Markdown and returned as HTML.
+
+=cut
 
 1;

--- a/lib/Sitegen/DataLoader.pm
+++ b/lib/Sitegen/DataLoader.pm
@@ -1,0 +1,59 @@
+package Sitegen::DataLoader;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use Text::Markdown::Discount qw(markdown);
+
+our @EXPORT_OK = qw(load_data load_announce);
+
+sub load_data {
+    my ($filename) = @_;
+    my %post;
+    my $iscontent = 0;
+
+    open(my $fh, '<', $filename) or die "Cannot open $filename: $!";
+    while (my $line = <$fh>) {
+        next if $line =~ m|^//|;
+        if ($iscontent == 0) {
+            chomp $line;
+            if    ($line =~ m/^Date:\s*(.+)$/)   { $post{date}   = $1 }
+            elsif ($line =~ m/^Author:\s*(.+)$/)  { $post{author} = $1 }
+            elsif ($line =~ m/^Title:\s*(.+)$/)   { $post{title}  = $1 }
+            elsif ($line =~ m/^Tags:\s*(.*)$/) {
+                my $raw = $1;
+                $post{tags} = [
+                    map  { my $t = $_; $t =~ s/^\s+|\s+$//g; lc $t }
+                    grep { /\S/ }
+                    split(/,/, $raw)
+                ];
+            }
+            elsif ($line =~ m/^Content:(.*)$/) {
+                $post{content} = $1;
+                $iscontent = 1;
+            }
+        } else {
+            $post{content} .= $line;
+        }
+    }
+    close $fh;
+
+    $post{tags}    //= [];
+    $post{content}   = markdown($post{content} // '');
+    return \%post;
+}
+
+sub load_announce {
+    my ($top_dir) = @_;
+    my @filelist;
+    opendir(my $dh, $top_dir) or die "Cannot open $top_dir: $!";
+    while (my $file = readdir($dh)) {
+        push @filelist, $file if $file =~ m/\.txt$/;
+    }
+    closedir($dh);
+    my @sortlist = sort @filelist;
+    my $filename = pop @sortlist;
+    return load_data("$top_dir/$filename");
+}
+
+1;

--- a/lib/Sitegen/SEO.pm
+++ b/lib/Sitegen/SEO.pm
@@ -1,0 +1,50 @@
+package Sitegen::SEO;
+
+use strict;
+use warnings;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(seo_meta);
+
+sub seo_meta {
+    my ($post, $config, $url_path) = @_;
+
+    my $content = $post->{content} // '';
+    (my $plain = $content) =~ s/<[^>]+>//g;
+    $plain =~ s/\s+/ /g;
+    $plain =~ s/^\s+|\s+$//g;
+
+    my $description = length($plain) > 0
+        ? substr($plain, 0, 160)
+        : ($config->{site_description} // '');
+
+    (my $base = $config->{site_url} // '') =~ s|/$||;
+
+    return {
+        description    => $description,
+        og_title       => $post->{title} // $config->{site_name} // '',
+        og_description => $description,
+        og_url         => "$base$url_path",
+    };
+}
+
+=head1 NAME
+
+Sitegen::SEO - Generate SEO meta hashref for hklug-sitegen pages
+
+=head1 SYNOPSIS
+
+  use Sitegen::SEO qw(seo_meta);
+
+  my $seo = seo_meta($post, $config, '/archive/20240101.html');
+  # Returns hashref: description, og_title, og_description, og_url
+
+=head1 DESCRIPTION
+
+Strips HTML from post content, truncates to 160 chars, and assembles
+the meta hashref consumed by the [% IF seo %] block in header.html.
+Falls back to C<site_description> from config when content is empty.
+
+=cut
+
+1;

--- a/lib/Sitegen/SEO.pm
+++ b/lib/Sitegen/SEO.pm
@@ -22,7 +22,7 @@ sub seo_meta {
 
     return {
         description    => $description,
-        og_title       => $post->{title} // $config->{site_name} // '',
+        og_title       => ($post->{title} || $config->{site_name} || ''),
         og_description => $description,
         og_url         => "$base$url_path",
     };

--- a/lib/Sitegen/Tags.pm
+++ b/lib/Sitegen/Tags.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Exporter 'import';
 use File::Path qw(make_path);
+use Sitegen::SEO qw(seo_meta);
 
 our @EXPORT_OK = qw(collect_tags tag_slug gen_tag_pages);
 
@@ -26,7 +27,7 @@ sub collect_tags {
 }
 
 sub gen_tag_pages {
-    my ($tt, $tags, $site_folder, $config) = @_;
+    my ($tt, $tags, $site_folder, $config, $announce) = @_;
     my $tags_folder = "$site_folder/tags";
     make_path($tags_folder);
 
@@ -35,7 +36,15 @@ sub gen_tag_pages {
     } sort keys %$tags;
 
     $tt->process('tag_list.html',
-        { title => $config->{site_name} . ' > Tags', tag_list => \@tag_list },
+        {
+            title    => $config->{site_name} . ' > Tags',
+            tag_list => \@tag_list,
+            announce => $announce,
+            seo      => seo_meta(
+                { title => $config->{site_name} . ' > Tags', content => '' },
+                $config, '/tags/'
+            ),
+        },
         "$tags_folder/index.html"
     ) || die $tt->error();
 
@@ -45,10 +54,15 @@ sub gen_tag_pages {
         make_path($tag_dir);
         $tt->process('tag_page.html',
             {
-                title => $config->{site_name} . " > Tag: $tag",
-                tag   => $tag,
-                slug  => $slug,
-                posts => $tags->{$tag},
+                title    => $config->{site_name} . " > Tag: $tag",
+                tag      => $tag,
+                slug     => $slug,
+                posts    => $tags->{$tag},
+                announce => $announce,
+                seo      => seo_meta(
+                    { title => $config->{site_name} . " > Tag: $tag", content => '' },
+                    $config, "/tags/$slug/"
+                ),
             },
             "$tag_dir/index.html"
         ) || die $tt->error();

--- a/lib/Sitegen/Tags.pm
+++ b/lib/Sitegen/Tags.pm
@@ -28,7 +28,7 @@ sub collect_tags {
 sub gen_tag_pages {
     my ($tt, $tags, $site_folder, $config) = @_;
     my $tags_folder = "$site_folder/tags";
-    make_path($tags_folder) unless -d $tags_folder;
+    make_path($tags_folder);
 
     my @tag_list = map {
         { name => $_, slug => tag_slug($_), count => scalar @{$tags->{$_}} }
@@ -42,7 +42,7 @@ sub gen_tag_pages {
     for my $tag (keys %$tags) {
         my $slug    = tag_slug($tag);
         my $tag_dir = "$tags_folder/$slug";
-        make_path($tag_dir) unless -d $tag_dir;
+        make_path($tag_dir);
         $tt->process('tag_page.html',
             {
                 title => $config->{site_name} . " > Tag: $tag",

--- a/lib/Sitegen/Tags.pm
+++ b/lib/Sitegen/Tags.pm
@@ -1,0 +1,86 @@
+package Sitegen::Tags;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use File::Path qw(make_path);
+
+our @EXPORT_OK = qw(collect_tags tag_slug gen_tag_pages);
+
+sub tag_slug {
+    my ($tag) = @_;
+    (my $slug = lc $tag) =~ s/\s+/-/g;
+    return $slug;
+}
+
+sub collect_tags {
+    my (@posts) = @_;
+    my %tags;
+    for my $post (@posts) {
+        for my $tag (@{$post->{tags} // []}) {
+            next unless defined $tag && length $tag;
+            push @{$tags{$tag}}, $post;
+        }
+    }
+    return \%tags;
+}
+
+sub gen_tag_pages {
+    my ($tt, $tags, $site_folder, $config) = @_;
+    my $tags_folder = "$site_folder/tags";
+    make_path($tags_folder) unless -d $tags_folder;
+
+    my @tag_list = map {
+        { name => $_, slug => tag_slug($_), count => scalar @{$tags->{$_}} }
+    } sort keys %$tags;
+
+    $tt->process('tag_list.html',
+        { title => $config->{site_name} . ' > Tags', tag_list => \@tag_list },
+        "$tags_folder/index.html"
+    ) || die $tt->error();
+
+    for my $tag (keys %$tags) {
+        my $slug    = tag_slug($tag);
+        my $tag_dir = "$tags_folder/$slug";
+        make_path($tag_dir) unless -d $tag_dir;
+        $tt->process('tag_page.html',
+            {
+                title => $config->{site_name} . " > Tag: $tag",
+                tag   => $tag,
+                slug  => $slug,
+                posts => $tags->{$tag},
+            },
+            "$tag_dir/index.html"
+        ) || die $tt->error();
+    }
+}
+
+=head1 NAME
+
+Sitegen::Tags - Tag collection and page generation for hklug-sitegen
+
+=head1 SYNOPSIS
+
+  use Sitegen::Tags qw(collect_tags tag_slug gen_tag_pages);
+
+  my $tags = collect_tags(@posts);
+  # Returns hashref: { 'linux' => [$post1, $post2], ... }
+
+  my $slug = tag_slug('Open Source');  # returns 'open-source'
+
+  gen_tag_pages($tt, $tags, $site_folder, $config);
+  # Creates site/tags/index.html and site/tags/<slug>/index.html
+
+=head1 DESCRIPTION
+
+C<collect_tags()> builds a tag-to-posts mapping from a list of post hashrefs.
+Each post must have a C<tags> key containing an arrayref of tag strings.
+
+C<tag_slug()> converts a tag name to a URL-safe slug: lowercased, spaces to hyphens.
+
+C<gen_tag_pages()> uses Template Toolkit to render tag index and per-tag pages.
+Requires templates C<tag_list.html> and C<tag_page.html>.
+
+=cut
+
+1;

--- a/t/Cache.t
+++ b/t/Cache.t
@@ -24,6 +24,7 @@ is($loaded->{'foo.txt'}, 'abc123', 'save and load round-trip');
 open(my $fh, '>', "$tmpdir/bad.json") or die $!;
 print $fh "NOT JSON {{{{";
 close $fh;
+local $SIG{__WARN__} = sub {};
 my $bad = load_cache("$tmpdir/bad.json");
 is(ref($bad), 'HASH', 'corrupt cache returns hashref');
 is(scalar keys %$bad, 0, 'corrupt cache is empty');

--- a/t/Cache.t
+++ b/t/Cache.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 9;
+use File::Temp qw(tempdir tempfile);
+use lib 'lib';
+
+use_ok('Sitegen::Cache', qw(load_cache save_cache is_fresh update_cache));
+
+my $tmpdir = tempdir(CLEANUP => 1);
+
+# Test 1: load_cache on missing file returns empty hashref
+my $cache = load_cache("$tmpdir/nonexistent.json");
+is(ref($cache), 'HASH', 'missing cache returns hashref');
+is(scalar keys %$cache, 0, 'missing cache is empty');
+
+# Test 2: save_cache then load_cache round-trips
+my $data = { 'foo.txt' => 'abc123' };
+save_cache("$tmpdir/cache.json", $data);
+my $loaded = load_cache("$tmpdir/cache.json");
+is($loaded->{'foo.txt'}, 'abc123', 'save and load round-trip');
+
+# Test 3: corrupt cache returns empty hashref with warning
+open(my $fh, '>', "$tmpdir/bad.json") or die $!;
+print $fh "NOT JSON {{{{";
+close $fh;
+my $bad = load_cache("$tmpdir/bad.json");
+is(ref($bad), 'HASH', 'corrupt cache returns hashref');
+is(scalar keys %$bad, 0, 'corrupt cache is empty');
+
+# Test 4: update_cache + is_fresh
+my $srcfile = "$tmpdir/article.txt";
+open($fh, '>', $srcfile) or die $!;
+print $fh "Date: 2024-01-01\nContent:\nHello.";
+close $fh;
+
+my $outfile = "$tmpdir/article.html";
+open($fh, '>', $outfile) or die $!; print $fh "<p>Hello.</p>"; close $fh;
+
+my $c = {};
+is(is_fresh($c, $srcfile, $outfile), 0, 'not fresh before update_cache');
+
+update_cache($c, $srcfile);
+is(is_fresh($c, $srcfile, $outfile), 1, 'fresh after update_cache');
+
+# Test 5: is_fresh returns 0 when output file missing
+unlink $outfile;
+is(is_fresh($c, $srcfile, $outfile), 0, 'not fresh when output file missing');

--- a/t/Cache.t
+++ b/t/Cache.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More;
 use File::Temp qw(tempdir tempfile);
 use lib 'lib';
 
@@ -30,12 +30,14 @@ is(scalar keys %$bad, 0, 'corrupt cache is empty');
 
 # Test 4: update_cache + is_fresh
 my $srcfile = "$tmpdir/article.txt";
-open($fh, '>', $srcfile) or die $!;
-print $fh "Date: 2024-01-01\nContent:\nHello.";
-close $fh;
+open(my $src_fh, '>', $srcfile) or die $!;
+print $src_fh "Date: 2024-01-01\nContent:\nHello.";
+close $src_fh;
 
 my $outfile = "$tmpdir/article.html";
-open($fh, '>', $outfile) or die $!; print $fh "<p>Hello.</p>"; close $fh;
+open(my $out_fh, '>', $outfile) or die $!;
+print $out_fh "<p>Hello.</p>";
+close $out_fh;
 
 my $c = {};
 is(is_fresh($c, $srcfile, $outfile), 0, 'not fresh before update_cache');
@@ -46,3 +48,18 @@ is(is_fresh($c, $srcfile, $outfile), 1, 'fresh after update_cache');
 # Test 5: is_fresh returns 0 when output file missing
 unlink $outfile;
 is(is_fresh($c, $srcfile, $outfile), 0, 'not fresh when output file missing');
+
+# Test 6: is_fresh returns 0 when source file missing
+is(is_fresh($c, "$tmpdir/nonexistent.txt", $outfile), 0, 'not fresh when source file missing');
+
+# Test 7: is_fresh returns 0 after source file content changes
+open(my $recreate_fh, '>', $outfile) or die $!;
+print $recreate_fh "<p>Hello.</p>";
+close $recreate_fh;
+
+open(my $mod_fh, '>', $srcfile) or die $!;
+print $mod_fh "Different content entirely.";
+close $mod_fh;
+is(is_fresh($c, $srcfile, $outfile), 0, 'not fresh after source content changes');
+
+done_testing();

--- a/t/DataLoader.t
+++ b/t/DataLoader.t
@@ -1,0 +1,69 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 10;
+use File::Temp qw(tempdir);
+use lib 'lib';
+
+use_ok('Sitegen::DataLoader', qw(load_data load_announce));
+
+my $tmpdir = tempdir(CLEANUP => 1);
+
+# Helper: write a temp .txt file
+sub write_txt {
+    my ($dir, $name, $content) = @_;
+    open(my $fh, '>', "$dir/$name") or die $!;
+    print $fh $content;
+    close $fh;
+    return "$dir/$name";
+}
+
+# Test 1: basic fields parsed
+my $f = write_txt($tmpdir, 'test1.txt', <<'END');
+Date: 2024-01-15 18:00
+Author: Wan Leung Wong
+Title: Test Post
+Content:
+Hello **world**.
+END
+my $post = load_data($f);
+is($post->{date},   '2024-01-15 18:00', 'date parsed');
+is($post->{author}, 'Wan Leung Wong',   'author parsed');
+is($post->{title},  'Test Post',        'title parsed');
+like($post->{content}, qr/<strong>world<\/strong>|<b>world<\/b>/, 'content markdown rendered');
+
+# Test 2: no Tags: line → empty arrayref
+is(ref($post->{tags}), 'ARRAY', 'tags is arrayref');
+is(scalar @{$post->{tags}}, 0, 'no tags = empty array');
+
+# Test 3: Tags: line parsed and lowercased
+my $f2 = write_txt($tmpdir, 'test2.txt', <<'END');
+Date: 2024-02-01 10:00
+Author: Bot
+Title: Tagged Post
+Tags: Linux, Open-Source, EVENT
+Content:
+Body.
+END
+my $post2 = load_data($f2);
+is_deeply($post2->{tags}, ['linux', 'open-source', 'event'], 'tags lowercased and trimmed');
+
+# Test 4: load_announce returns most recent file
+my $topdir = "$tmpdir/top";
+mkdir $topdir;
+write_txt($topdir, '001.txt', "Date: 2024-01-01\nAuthor: A\nTitle: Old\nContent:\nOld.");
+write_txt($topdir, '002.txt', "Date: 2024-02-01\nAuthor: B\nTitle: New\nContent:\nNew.");
+my $announce = load_announce($topdir);
+is($announce->{title}, 'New', 'load_announce returns most recent file');
+
+# Test 5: comment lines skipped
+my $f3 = write_txt($tmpdir, 'test3.txt', <<'END');
+// this is a comment
+Date: 2024-03-01 09:00
+Author: Bot
+Title: With Comment
+Content:
+Body.
+END
+my $post3 = load_data($f3);
+is($post3->{date}, '2024-03-01 09:00', 'comment lines skipped');

--- a/t/DataLoader.t
+++ b/t/DataLoader.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 10;
+use Test::More tests => 12;
 use File::Temp qw(tempdir);
 use lib 'lib';
 
@@ -67,3 +67,21 @@ Body.
 END
 my $post3 = load_data($f3);
 is($post3->{date}, '2024-03-01 09:00', 'comment lines skipped');
+
+# Test 6: // lines in content body are preserved
+my $f4 = write_txt($tmpdir, 'test4.txt', <<'END');
+Date: 2024-04-01
+Author: Bot
+Title: Code Post
+Content:
+Line one.
+// this should NOT be stripped from content
+Line two.
+END
+my $post4 = load_data($f4);
+like($post4->{content}, qr/this should NOT be stripped/, '// lines in content body are preserved');
+
+# Test 7: Tags: with no value gives empty array
+my $f5 = write_txt($tmpdir, 'test5.txt', "Date: 2024-05-01\nAuthor: A\nTitle: T\nTags:\nContent:\nBody.\n");
+my $post5 = load_data($f5);
+is(scalar @{$post5->{tags}}, 0, 'Tags: with no value gives empty array');

--- a/t/DataLoader.t
+++ b/t/DataLoader.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 12;
+use Test::More tests => 13;
 use File::Temp qw(tempdir);
 use lib 'lib';
 
@@ -12,7 +12,7 @@ my $tmpdir = tempdir(CLEANUP => 1);
 # Helper: write a temp .txt file
 sub write_txt {
     my ($dir, $name, $content) = @_;
-    open(my $fh, '>', "$dir/$name") or die $!;
+    open(my $fh, '>:encoding(UTF-8)', "$dir/$name") or die $!;
     print $fh $content;
     close $fh;
     return "$dir/$name";
@@ -85,3 +85,8 @@ like($post4->{content}, qr/this should NOT be stripped/, '// lines in content bo
 my $f5 = write_txt($tmpdir, 'test5.txt', "Date: 2024-05-01\nAuthor: A\nTitle: T\nTags:\nContent:\nBody.\n");
 my $post5 = load_data($f5);
 is(scalar @{$post5->{tags}}, 0, 'Tags: with no value gives empty array');
+
+# Test 8: load_announce dies on empty dir
+my $emptydir = "$tmpdir/empty"; mkdir $emptydir;
+eval { load_announce($emptydir) };
+like($@, qr/No .txt files found/, 'load_announce dies on empty dir');

--- a/t/DataLoader.t
+++ b/t/DataLoader.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 13;
+use Test::More tests => 15;
 use File::Temp qw(tempdir);
 use lib 'lib';
 
@@ -90,3 +90,11 @@ is(scalar @{$post5->{tags}}, 0, 'Tags: with no value gives empty array');
 my $emptydir = "$tmpdir/empty"; mkdir $emptydir;
 eval { load_announce($emptydir) };
 like($@, qr/No .txt files found/, 'load_announce dies on empty dir');
+
+# Test 9: unsafe tags (path traversal) are skipped with a warning
+my $f6 = write_txt($tmpdir, 'test6.txt', "Date: 2024-06-01\nAuthor: A\nTitle: T\nTags: linux, ../evil, good-tag, /etc/passwd\nContent:\nBody.\n");
+my @warnings;
+local $SIG{__WARN__} = sub { push @warnings, @_ };
+my $post6 = load_data($f6);
+is_deeply($post6->{tags}, ['linux', 'good-tag'], 'unsafe tags skipped');
+is(scalar @warnings, 2, 'two warnings emitted for two unsafe tags');

--- a/t/SEO.t
+++ b/t/SEO.t
@@ -40,4 +40,12 @@ my $cfg2 = { %$config, site_url => 'https://hklug.org/' };
 my $seo4 = seo_meta($post, $cfg2, '/archive/x.html');
 is($seo4->{og_url}, 'https://hklug.org/archive/x.html', 'trailing slash stripped from site_url');
 
+# Test 8: og_title falls back to site_name when title absent
+my $seo5 = seo_meta({ content => '' }, $config, '/');
+is($seo5->{og_title}, 'HKLUG', 'og_title falls back to site_name');
+
+# Test 9: whitespace-only content falls back to site_description
+my $seo6 = seo_meta({ title => 'T', content => '<p>   </p>' }, $config, '/');
+is($seo6->{description}, 'Linux users in HK.', 'whitespace-only content uses site_description');
+
 done_testing();

--- a/t/SEO.t
+++ b/t/SEO.t
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use lib 'lib';
+
+use_ok('Sitegen::SEO', qw(seo_meta));
+
+my $config = {
+    site_url         => 'https://hklug.org',
+    site_name        => 'HKLUG',
+    site_description => 'Linux users in HK.',
+};
+
+# Test 1: og_url constructed correctly
+my $post = { title => 'My Post', content => '<p>Hello world.</p>' };
+my $seo  = seo_meta($post, $config, '/archive/20240101-120000.html');
+is($seo->{og_url}, 'https://hklug.org/archive/20240101-120000.html', 'og_url correct');
+
+# Test 2: og_title from post title
+is($seo->{og_title}, 'My Post', 'og_title from post title');
+
+# Test 3: HTML stripped from description
+is($seo->{description}, 'Hello world.', 'HTML stripped from description');
+
+# Test 4: description same as og_description
+is($seo->{description}, $seo->{og_description}, 'description == og_description');
+
+# Test 5: long content truncated to 160 chars
+my $long = 'A' x 200;
+my $seo2 = seo_meta({ title => 'T', content => $long }, $config, '/');
+is(length($seo2->{description}), 160, 'description truncated to 160 chars');
+
+# Test 6: empty content falls back to site_description
+my $seo3 = seo_meta({ title => 'T', content => '' }, $config, '/');
+is($seo3->{description}, 'Linux users in HK.', 'empty content uses site_description');
+
+# Test 7: trailing slash removed from site_url
+my $cfg2 = { %$config, site_url => 'https://hklug.org/' };
+my $seo4 = seo_meta($post, $cfg2, '/archive/x.html');
+is($seo4->{og_url}, 'https://hklug.org/archive/x.html', 'trailing slash stripped from site_url');
+
+done_testing();

--- a/t/Tags.t
+++ b/t/Tags.t
@@ -25,4 +25,13 @@ is(scalar @{$tags->{event}}, 2, 'event has 2 posts');
 is(scalar @{$tags->{'open-source'}}, 1, 'open-source has 1 post');
 ok(!exists $tags->{''}, 'empty tags not included');
 
+# Test: undef tag and missing tags key handled gracefully
+my @posts_with_undef = (
+    { title => 'Post X', tags => [undef, 'linux'] },
+    { title => 'Post Y' },
+);
+my $tags2 = collect_tags(@posts_with_undef);
+ok(!exists $tags2->{''}, 'undef tag skipped');
+is(scalar @{$tags2->{linux}}, 1, 'valid tag alongside undef still collected');
+
 done_testing();

--- a/t/Tags.t
+++ b/t/Tags.t
@@ -1,0 +1,28 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use lib 'lib';
+
+use_ok('Sitegen::Tags', qw(collect_tags tag_slug));
+
+# Test 1: tag_slug lowercases and replaces spaces
+is(tag_slug('Open Source'), 'open-source', 'spaces become hyphens');
+is(tag_slug('Linux'),       'linux',       'already lowercase unchanged');
+is(tag_slug('AI & ML'),    'ai-&-ml',     'non-space chars preserved');
+
+# Test 2: collect_tags builds tag->posts map
+my @posts = (
+    { title => 'Post A', tags => ['linux', 'event'] },
+    { title => 'Post B', tags => ['linux'] },
+    { title => 'Post C', tags => ['event', 'open-source'] },
+    { title => 'Post D', tags => [] },
+);
+my $tags = collect_tags(@posts);
+is(ref($tags), 'HASH', 'collect_tags returns hashref');
+is(scalar @{$tags->{linux}}, 2, 'linux has 2 posts');
+is(scalar @{$tags->{event}}, 2, 'event has 2 posts');
+is(scalar @{$tags->{'open-source'}}, 1, 'open-source has 1 post');
+ok(!exists $tags->{''}, 'empty tags not included');
+
+done_testing();

--- a/template/header.html
+++ b/template/header.html
@@ -6,7 +6,14 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hong Kong Linux User Group (HKLUG)</title>
+    <title>[% title %]</title>
+    [% IF seo %]
+    <meta name="description" content="[% seo.description | html %]" />
+    <meta property="og:title" content="[% seo.og_title | html %]" />
+    <meta property="og:description" content="[% seo.og_description | html %]" />
+    <meta property="og:url" content="[% seo.og_url %]" />
+    <link rel="canonical" href="[% seo.og_url %]" />
+    [% END %]
     <link rel="stylesheet" href="/css/foundation.css" />
     <link rel="stylesheet" href="/css/main.css" />
     <script src="/js/vendor/modernizr.js"></script>

--- a/template/header.html
+++ b/template/header.html
@@ -6,7 +6,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>[% title %]</title>
+    <title>[% title | html %]</title>
     [% IF seo %]
     <meta name="description" content="[% seo.description | html %]" />
     <meta property="og:title" content="[% seo.og_title | html %]" />

--- a/template/header.html
+++ b/template/header.html
@@ -11,8 +11,8 @@
     <meta name="description" content="[% seo.description | html %]" />
     <meta property="og:title" content="[% seo.og_title | html %]" />
     <meta property="og:description" content="[% seo.og_description | html %]" />
-    <meta property="og:url" content="[% seo.og_url %]" />
-    <link rel="canonical" href="[% seo.og_url %]" />
+    <meta property="og:url" content="[% seo.og_url | html %]" />
+    <link rel="canonical" href="[% seo.og_url | html %]" />
     [% END %]
     <link rel="stylesheet" href="/css/foundation.css" />
     <link rel="stylesheet" href="/css/main.css" />

--- a/template/post.html
+++ b/template/post.html
@@ -9,6 +9,11 @@
           [% post.content %]
         </p>
 
+      [% IF post.tags.size %]
+      <p class="post-tags">Tags:
+        [% FOREACH tag = post.tags %]<a href="/tags/[% tag | uri %]/">[% tag | html %]</a>[% UNLESS loop.last %], [% END %][% END %]
+      </p>
+      [% END %]
       </article>
       <hr />
 

--- a/template/post.html
+++ b/template/post.html
@@ -11,7 +11,7 @@
 
       [% IF post.tags.size %]
       <p class="post-tags">Tags:
-        [% FOREACH tag = post.tags %]<a href="/tags/[% tag.replace('\s+', '-') %]/">[% tag | html %]</a>[% UNLESS loop.last %], [% END %][% END %]
+        [% FOREACH tag = post.tags %]<a href="/tags/[% tag.replace('\s+', '-') | html %]/">[% tag | html %]</a>[% UNLESS loop.last %], [% END %][% END %]
       </p>
       [% END %]
       </article>

--- a/template/post.html
+++ b/template/post.html
@@ -11,7 +11,7 @@
 
       [% IF post.tags.size %]
       <p class="post-tags">Tags:
-        [% FOREACH tag = post.tags %]<a href="/tags/[% tag.replace('\s+', '-') | html %]/">[% tag | html %]</a>[% UNLESS loop.last %], [% END %][% END %]
+        [% FOREACH tag = post.tags %]<a href="/tags/[% tag.replace('\s+', '-') | uri %]/">[% tag | html %]</a>[% UNLESS loop.last %], [% END %][% END %]
       </p>
       [% END %]
       </article>

--- a/template/post.html
+++ b/template/post.html
@@ -11,7 +11,7 @@
 
       [% IF post.tags.size %]
       <p class="post-tags">Tags:
-        [% FOREACH tag = post.tags %]<a href="/tags/[% tag | uri %]/">[% tag | html %]</a>[% UNLESS loop.last %], [% END %][% END %]
+        [% FOREACH tag = post.tags %]<a href="/tags/[% tag.replace('\s+', '-') %]/">[% tag | html %]</a>[% UNLESS loop.last %], [% END %][% END %]
       </p>
       [% END %]
       </article>

--- a/template/tag_list.html
+++ b/template/tag_list.html
@@ -1,0 +1,14 @@
+[% WRAPPER frame.html %]
+
+  <h2>All Tags</h2>
+  [% IF tag_list.size %]
+  <ul class="tag-list">
+    [% FOREACH t = tag_list %]
+    <li><a href="/tags/[% t.slug | uri %]/">[% t.name | html %]</a> ([% t.count %])</li>
+    [% END %]
+  </ul>
+  [% ELSE %]
+  <p>No tags yet.</p>
+  [% END %]
+
+[% END %]

--- a/template/tag_page.html
+++ b/template/tag_page.html
@@ -1,0 +1,9 @@
+[% WRAPPER frame.html %]
+
+  <h2>Posts tagged: [% tag | html %]</h2>
+  [% FOREACH post = posts %]
+    [% PROCESS post.html %]
+  [% END %]
+  <p><a href="/tags/">← All Tags</a></p>
+
+[% END %]

--- a/template/tag_page.html
+++ b/template/tag_page.html
@@ -1,8 +1,12 @@
 [% WRAPPER frame.html %]
 
   <h2>Posts tagged: [% tag | html %]</h2>
+  [% IF posts.size %]
   [% FOREACH post = posts %]
     [% PROCESS post.html %]
+  [% END %]
+  [% ELSE %]
+  <p>No posts found for this tag.</p>
   [% END %]
   <p><a href="/tags/">← All Tags</a></p>
 


### PR DESCRIPTION
## Summary

- **SEO meta tags**: Added `<meta>` description, Open Graph (`og:title`, `og:description`, `og:url`), and `<link rel="canonical">` to all archive pages and new tag pages, driven by `data/sitegen.yaml` site config
- **Tag pages**: Added tag collection from article `Tags:` header lines; generates `/tags/index.html` (all-tags list) and `/tags/<slug>/index.html` (per-tag post list)
- **Incremental generation**: SHA-256 cache (`data/.sitegen-cache.json`) skips unchanged archive pages on re-run; `--force` flag bypasses cache to regenerate everything

## New modules

- `lib/Sitegen/DataLoader.pm` — article file parser with `Tags:` support
- `lib/Sitegen/Cache.pm` — SHA-256 incremental cache with atomic writes
- `lib/Sitegen/SEO.pm` — SEO meta hashref builder
- `lib/Sitegen/Tags.pm` — tag collection and tag page generation

## Test Plan

- [x] 45 unit tests pass (`prove -l t/`)
- [x] End-to-end smoke test: 358 archive pages generated, 358 SKIPs on second run, 0 SKIPs with `--force`
- [x] SEO tags verified in generated HTML output
- [x] Tag pages verified with announce block and SEO meta